### PR TITLE
chore: fix typos (from #13)

### DIFF
--- a/argo-workflows/templates/container.md
+++ b/argo-workflows/templates/container.md
@@ -1,17 +1,17 @@
-A container template is the most common type of template, lets look at a complete example:
+A container template is the most common type of template, let's look at a complete example:
 
 ```
 apiVersion: argoproj.io/v1alpha1
-kind: Workflow                 
+kind: Workflow
 metadata:
-  generateName: container-   
+  generateName: container-
 spec:
-  entrypoint: main         
+  entrypoint: main
   templates:
-  - name: main             
+  - name: main
     container:
       image: docker/whalesay
-      command: [cowsay]         
+      command: [cowsay]
       args: ["hello world"]
 ```
 

--- a/argo-workflows/templates/exit-handler.md
+++ b/argo-workflows/templates/exit-handler.md
@@ -11,7 +11,7 @@ using `onExit`:
 
 They just state the name of the template that should be run on-exit.
 
-Lets look at a complete example:
+Let's look at a complete example:
 
 `cat exit-handler-workflow.yaml`{{execute}}
 
@@ -23,9 +23,9 @@ You should see:
 
 ```
 STEP                   TEMPLATE  PODNAME                        DURATION  MESSAGE
- ✔ exit-handler-plvg7  main                                                 
- ├─✔ a                 whalesay  exit-handler-plvg7-1651124468  5s          
- └─✔ a.onExit          tidy-up   exit-handler-plvg7-3635807335  6s          
+ ✔ exit-handler-plvg7  main
+ ├─✔ a                 whalesay  exit-handler-plvg7-1651124468  5s
+ └─✔ a.onExit          tidy-up   exit-handler-plvg7-3635807335  6s
 ```
 
 Note how the exit handler task ran last.

--- a/argo-workflows/templates/work.md
+++ b/argo-workflows/templates/work.md
@@ -12,7 +12,7 @@ A **resource template** allows you to create a Kubernetes resource and wait for 
 A **script template** allows you to run a script in a container. This is very similar to a container template, but when
 you've added a script to it.
 
-Every type of template that does work does it by running a pod. You can use `kubectl` to view these pods:
+Every type of template that does work, does so by running a pod. You can use `kubectl` to view these pods:
 
 `kubectl get pods -l workflows.argoproj.io/workflow`{{execute}}
 
@@ -28,5 +28,5 @@ template-tag-kqpc6   0/2     Completed   0          4m6s
 
 ## Exercise
 
-Use `kubectl describe` to describe a workflow pod. What interesting information is contained within the pod labels
+Use `kubectl describe` to describe a workflow pod. What interesting information is contained within the pod's labels
 and annotations?


### PR DESCRIPTION
This is an updated version of PR #13 which had gone stale.

Most of the typos had already been fixed in my migration to killercoda, but this rolls up the last few without making @noamsan do a bunch of work to catch up.