### PR TITLE
fix: assign the correct serviceAccount to the workflows

### DIFF
--- a/argo-workflows/getting-started/assets/hello-workflow.yaml
+++ b/argo-workflows/getting-started/assets/hello-workflow.yaml
@@ -1,8 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  name: hello
+  generateName: hello-
 spec:
+  serviceAccountName: argo
   entrypoint: main
   templates:
     - name: main

--- a/argo-workflows/getting-started/ui.md
+++ b/argo-workflows/getting-started/ui.md
@@ -51,9 +51,10 @@ metadata:
   generateName: hello-world-
   namespace: argo
 spec:
-  entrypoint: main        
+  serviceAccountName: argo
+  entrypoint: main
   templates:
-  - name: main           
+  - name: main
     container:
       image: docker/whalesay
       command: ["cowsay"]

--- a/argo-workflows/getting-started/workflow.md
+++ b/argo-workflows/getting-started/workflow.md
@@ -6,11 +6,11 @@ container.
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  name: hello  
+  name: hello
 spec:
-  entrypoint: main # the first template to run in the workflows        
+  entrypoint: main # the first template to run in the workflows
   templates:
-  - name: main           
+  - name: main
     container: # this is a container template
       image: docker/whalesay # this image prints "hello world" to the console
       command: ["cowsay"]
@@ -22,7 +22,7 @@ Because a workflow is just a Kubernetes resource, you can use `kubectl` with the
 
 Create a workflow:
 
-`kubectl -n argo apply -f hello-workflow.yaml`{{execute}}
+`kubectl -n argo create -f hello-workflow.yaml`{{execute}}
 
 Then you can wait for it to complete (around 1m):
 


### PR DESCRIPTION
Fixes #31 


- Ensures that the inbuilt `argo` serviceaccount is used
- Swaps the first workflow to have `generateName` so that it can be run more than once if the user wishes.