### PR TITLE
fix: install using helm ui

### DIFF
--- a/argo-workflows/install-using-helm/install.md
+++ b/argo-workflows/install-using-helm/install.md
@@ -2,7 +2,10 @@ This command installs the latest Argo Workflows Helm Chart. In production it wou
 ```bash
 helm repo add argo https://argoproj.github.io/argo-helm
 helm repo update
-helm install argo argo/argo-workflows --namespace argo --create-namespace
+helm install argo argo/argo-workflows \
+  --namespace argo \
+  --create-namespace \
+  --set workflow.serviceAccount.create=true
 ```{{execute}}
 
 ## What was installed?

--- a/argo-workflows/install-using-helm/ui.md
+++ b/argo-workflows/install-using-helm/ui.md
@@ -44,7 +44,7 @@ metadata:
   generateName: hello-world-
   namespace: argo
 spec:
-  serviceAccountName: argo-argo-workflows-workflow-controller
+  serviceAccountName: argo-workflow
   entrypoint: main
   templates:
     - name: main

--- a/argo-workflows/install-using-helm/ui.md
+++ b/argo-workflows/install-using-helm/ui.md
@@ -44,6 +44,7 @@ metadata:
   generateName: hello-world-
   namespace: argo
 spec:
+  serviceAccountName: argo-argo-workflows-workflow-controller
   entrypoint: main
   templates:
     - name: main


### PR DESCRIPTION
This fix:

Error (exit code 1): pods "hello-world1-6wf5p" is forbidden: User "system:serviceaccount:argo:default" cannot patch resource "pods" in API group "" in the namespace "argo"

See:
https://github.com/argoproj/argo-workflows/issues/12391
https://github.com/argoproj/argo-workflows/issues/12783