### PR TITLE
Skipping the installation of Argo Workflows 3.6.x releases until ClusterRole bug is fixed

### DIFF
--- a/argo-workflows/getting-started/install.md
+++ b/argo-workflows/getting-started/install.md
@@ -6,6 +6,8 @@ Argo is normally installed into a namespace named `argo`, so lets create that:
 
 Next, navigate to the [releases page](https://github.com/argoproj/argo-workflows/releases/latest) and find the release you wish to use (the latest full release is preferred).
 
+> There is an issue in Argo Workflows 3.6.x releases where some permissions are missing in **argo-cluster-role** ClusterRole. Install the latest 3.5 minor release instead.
+
 Scroll down to the `Controller and Server`{{}} section and execute the kubectl commands.
 
 Below is an example of the install commands, ensure that you update the command to install the correct version number:

--- a/argo-workflows/getting-started/workflow.md
+++ b/argo-workflows/getting-started/workflow.md
@@ -23,6 +23,23 @@ There are several other types of templates, and we'll come to more of them soon.
 
 Because a workflow is just a Kubernetes resource, you can use `kubectl` with them.
 
+> There is an issue in Argo Workflows 3.6.x releases where some permissions are missing in **argo-cluster-role** ClusterRole. If you have installed one of those affected versions, you must modify the **argo-cluster-role** ClusterRole, ensuring the role allows both `create` and `patch` verbs over the `workflowtaskresults` resources:
+
+`kubectl edit clusterrole argo-cluster-role`
+
+```
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtaskresults
+  verbs:
+  - list
+  - watch
+  - deletecollection
+  - create
+  - patch
+```
+
 Create a workflow:
 
 `kubectl -n argo apply -f hello-workflow.yaml`{{execute}}


### PR DESCRIPTION
Skipping the installation of Argo Workflows 3.6.x releases until this bug [1] is solved.

Also, the PR provides a workaround for editing the ClusterRole `argo-cluster-role` in case a 3.6.x release has been installed.

[1] https://github.com/argoproj/argo-workflows/issues/13341